### PR TITLE
Feature/#25 좋아요 구현

### DIFF
--- a/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
+++ b/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
@@ -10,10 +10,6 @@ import com.revup.user.util.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 
 import static com.revup.global.util.ResponseUtil.success;
@@ -27,6 +23,7 @@ public class HeartController {
     private final UserUtil userUtil;
 
     @PostMapping
+    public ResponseEntity<ApiResponse<HeartIdResponse>> create(@RequestBody HeartCreateRequest request) {
         User currentUser = userUtil.getCurrentUser();
         return success(HttpStatus.CREATED, createHeartUseCase.execute(request, currentUser));
     }

--- a/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
+++ b/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
@@ -10,6 +10,10 @@ import com.revup.user.util.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 
 import static com.revup.global.util.ResponseUtil.success;
@@ -23,7 +27,6 @@ public class HeartController {
     private final UserUtil userUtil;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<HeartIdResponse>> create(@RequestBody HeartCreateRequest request) {
         User currentUser = userUtil.getCurrentUser();
         return success(HttpStatus.CREATED, createHeartUseCase.execute(request, currentUser));
     }

--- a/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
+++ b/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
@@ -1,0 +1,31 @@
+package com.revup.heart.controller;
+
+import com.revup.global.dto.ApiResponse;
+import com.revup.heart.dto.request.HeartCreateRequest;
+import com.revup.heart.dto.response.HeartIdResponse;
+import com.revup.heart.usecase.CreateHeartUseCase;
+import com.revup.user.entity.User;
+import com.revup.user.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.revup.global.util.ResponseUtil.success;
+
+@RestController
+@RequestMapping("/api/v1/heart")
+@RequiredArgsConstructor
+public class HeartController {
+    private final CreateHeartUseCase createHeartUseCase;
+    private final UserUtil userUtil;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<HeartIdResponse>> insert(@RequestBody HeartCreateRequest request) {
+        User currentUser = userUtil.getCurrentUser();
+        return success(HttpStatus.CREATED, createHeartUseCase.execute(request, currentUser));
+    }
+}

--- a/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
+++ b/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
@@ -28,9 +28,10 @@ public class HeartController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> delete(@RequestParam Long id,
+    public ResponseEntity<Void> delete(@RequestParam Long answerId,
+                                       @RequestParam boolean isGood,
                                        @SecurityUser User currentUser) {
-        deleteHeartUseCase.execute(id, currentUser);
+        deleteHeartUseCase.execute(answerId, currentUser, isGood);
         return ResponseEntity.noContent().build();
     }
 }

--- a/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
+++ b/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
@@ -4,15 +4,13 @@ import com.revup.global.dto.ApiResponse;
 import com.revup.heart.dto.request.HeartCreateRequest;
 import com.revup.heart.dto.response.HeartIdResponse;
 import com.revup.heart.usecase.CreateHeartUseCase;
+import com.revup.heart.usecase.DeleteHeartUseCase;
 import com.revup.user.entity.User;
 import com.revup.user.util.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.revup.global.util.ResponseUtil.success;
 
@@ -21,11 +19,19 @@ import static com.revup.global.util.ResponseUtil.success;
 @RequiredArgsConstructor
 public class HeartController {
     private final CreateHeartUseCase createHeartUseCase;
+    private final DeleteHeartUseCase deleteHeartUseCase;
     private final UserUtil userUtil;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<HeartIdResponse>> insert(@RequestBody HeartCreateRequest request) {
+    public ResponseEntity<ApiResponse<HeartIdResponse>> create(@RequestBody HeartCreateRequest request) {
         User currentUser = userUtil.getCurrentUser();
         return success(HttpStatus.CREATED, createHeartUseCase.execute(request, currentUser));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> delete(@RequestParam Long id) {
+        User currentUser = userUtil.getCurrentUser();
+        deleteHeartUseCase.execute(id, currentUser);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
+++ b/RevUp-api/src/main/java/com/revup/heart/controller/HeartController.java
@@ -1,12 +1,12 @@
 package com.revup.heart.controller;
 
+import com.revup.annotation.SecurityUser;
 import com.revup.global.dto.ApiResponse;
 import com.revup.heart.dto.request.HeartCreateRequest;
 import com.revup.heart.dto.response.HeartIdResponse;
 import com.revup.heart.usecase.CreateHeartUseCase;
 import com.revup.heart.usecase.DeleteHeartUseCase;
 import com.revup.user.entity.User;
-import com.revup.user.util.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,17 +20,16 @@ import static com.revup.global.util.ResponseUtil.success;
 public class HeartController {
     private final CreateHeartUseCase createHeartUseCase;
     private final DeleteHeartUseCase deleteHeartUseCase;
-    private final UserUtil userUtil;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<HeartIdResponse>> create(@RequestBody HeartCreateRequest request) {
-        User currentUser = userUtil.getCurrentUser();
+    public ResponseEntity<ApiResponse<HeartIdResponse>> create(@RequestBody HeartCreateRequest request,
+                                                               @SecurityUser User currentUser) {
         return success(HttpStatus.CREATED, createHeartUseCase.execute(request, currentUser));
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> delete(@RequestParam Long id) {
-        User currentUser = userUtil.getCurrentUser();
+    public ResponseEntity<Void> delete(@RequestParam Long id,
+                                       @SecurityUser User currentUser) {
         deleteHeartUseCase.execute(id, currentUser);
         return ResponseEntity.noContent().build();
     }

--- a/RevUp-api/src/main/java/com/revup/heart/dto/request/HeartCreateRequest.java
+++ b/RevUp-api/src/main/java/com/revup/heart/dto/request/HeartCreateRequest.java
@@ -1,0 +1,7 @@
+package com.revup.heart.dto.request;
+
+public record HeartCreateRequest(
+        Long answerId,
+        String type
+) {
+}

--- a/RevUp-api/src/main/java/com/revup/heart/dto/response/HeartIdResponse.java
+++ b/RevUp-api/src/main/java/com/revup/heart/dto/response/HeartIdResponse.java
@@ -1,0 +1,6 @@
+package com.revup.heart.dto.response;
+
+public record HeartIdResponse(
+        Long id
+) {
+}

--- a/RevUp-api/src/main/java/com/revup/heart/mapper/HeartMapper.java
+++ b/RevUp-api/src/main/java/com/revup/heart/mapper/HeartMapper.java
@@ -1,0 +1,18 @@
+package com.revup.heart.mapper;
+
+import com.revup.heart.dto.request.HeartCreateRequest;
+import com.revup.heart.entity.Heart;
+import com.revup.heart.enums.HeartType;
+import com.revup.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HeartMapper {
+    public Heart toEntity(HeartCreateRequest request, User currentUser) {
+        return Heart.builder()
+                .type(HeartType.of(request.type()))
+                .user(currentUser)
+                .build();
+    }
+
+}

--- a/RevUp-api/src/main/java/com/revup/heart/usecase/CreateHeartUseCase.java
+++ b/RevUp-api/src/main/java/com/revup/heart/usecase/CreateHeartUseCase.java
@@ -1,0 +1,22 @@
+package com.revup.heart.usecase;
+
+import com.revup.heart.dto.request.HeartCreateRequest;
+import com.revup.heart.dto.response.HeartIdResponse;
+import com.revup.heart.entity.Heart;
+import com.revup.heart.mapper.HeartMapper;
+import com.revup.heart.service.HeartService;
+import com.revup.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreateHeartUseCase {
+    private final HeartService heartService;
+    private final HeartMapper heartMapper;
+    public HeartIdResponse execute(HeartCreateRequest request, User currentUser) {
+        Heart heart = heartMapper.toEntity(request, currentUser);
+
+        heartService.createHeart(request.answerId(), heart, currentUser);
+    }
+}

--- a/RevUp-api/src/main/java/com/revup/heart/usecase/CreateHeartUseCase.java
+++ b/RevUp-api/src/main/java/com/revup/heart/usecase/CreateHeartUseCase.java
@@ -17,6 +17,8 @@ public class CreateHeartUseCase {
     public HeartIdResponse execute(HeartCreateRequest request, User currentUser) {
         Heart heart = heartMapper.toEntity(request, currentUser);
 
-        heartService.createHeart(request.answerId(), heart, currentUser);
+        Long id = heartService.createHeart(request.answerId(), heart, currentUser);
+
+        return new HeartIdResponse(id);
     }
 }

--- a/RevUp-api/src/main/java/com/revup/heart/usecase/CreateHeartUseCase.java
+++ b/RevUp-api/src/main/java/com/revup/heart/usecase/CreateHeartUseCase.java
@@ -17,7 +17,7 @@ public class CreateHeartUseCase {
     public HeartIdResponse execute(HeartCreateRequest request, User currentUser) {
         Heart heart = heartMapper.toEntity(request, currentUser);
 
-        Long id = heartService.createHeart(request.answerId(), heart, currentUser);
+        Long id = heartService.processHeart(request.answerId(), heart, currentUser);
 
         return new HeartIdResponse(id);
     }

--- a/RevUp-api/src/main/java/com/revup/heart/usecase/DeleteHeartUseCase.java
+++ b/RevUp-api/src/main/java/com/revup/heart/usecase/DeleteHeartUseCase.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class DeleteHeartUseCase {
     private final HeartService heartService;
 
-    public void execute(Long id, User currentUser){
-        heartService.deleteHeart(id, currentUser);
+    public void execute(Long answerId, User currentUser,boolean isGood){
+        heartService.cancelHeart(answerId, currentUser, isGood);
     }
 }

--- a/RevUp-api/src/main/java/com/revup/heart/usecase/DeleteHeartUseCase.java
+++ b/RevUp-api/src/main/java/com/revup/heart/usecase/DeleteHeartUseCase.java
@@ -1,0 +1,16 @@
+package com.revup.heart.usecase;
+
+import com.revup.heart.service.HeartService;
+import com.revup.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteHeartUseCase {
+    private final HeartService heartService;
+
+    public void execute(Long id, User currentUser){
+        heartService.deleteHeart(id, currentUser);
+    }
+}

--- a/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
+++ b/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
@@ -64,7 +64,8 @@ public enum ErrorCode {
     ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" ),
 
     HEART_TYPE_INVALID(BAD_REQUEST, "잘못된 반응 타입입니다"),
-    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),;
+    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),
+    HEART_NOT_FOUND(NOT_FOUND, "반응 id : %s 가 존재하지 않습니다"),;
 
     private final HttpStatus httpStatus;
     private final String messageTemplate;

--- a/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
+++ b/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
@@ -61,6 +61,11 @@ public enum ErrorCode {
     ANSWER_NOT_FOUND(NOT_FOUND, "답변 id : %s 가 존재하지 않습니다"),
     ADOPTED_REVIEW_INVALID(BAD_REQUEST,"올바르지 않은 채택 리뷰입니다" ),
     ANSWER_ALREADY_ADOPTED(CONFLICT, "이미 채택된 답변입니다"),
+    ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" ),
+
+    HEART_TYPE_INVALID(BAD_REQUEST, "잘못된 반응 타입입니다"),
+    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),
+    HEART_NOT_FOUND(NOT_FOUND, "반응 id : %s 가 존재하지 않습니다"),
     ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" );
 
     private final HttpStatus httpStatus;

--- a/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
+++ b/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     INVALID_CERTIFICATION_NUMBER(BAD_REQUEST, "인증 번호가 유효하지 않습니다."),
     USER_PERMISSION(FORBIDDEN, "권한이 없는 사용자입니다"),
     USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 id : %s 가 존재하지 않습니다"),
+    EMAIL_DOMAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 도메인이 존재하지 않습니다"),
 
     //Infra Exception
     OTHER_SERVER_BAD_REQUEST(BAD_REQUEST, "외부 api 400에러"),

--- a/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
+++ b/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
@@ -65,8 +65,8 @@ public enum ErrorCode {
     ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" ),
 
     HEART_TYPE_INVALID(BAD_REQUEST, "잘못된 반응 타입입니다"),
-    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),
-    HEART_NOT_FOUND(NOT_FOUND, "반응 id : %s 가 존재하지 않습니다"),;
+    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 좋아요/싫어요가 존재합니다"),
+    HEART_NOT_FOUND(NOT_FOUND, "해당 좋아요/싫어요가 존재하지 않습니다"),;
 
     private final HttpStatus httpStatus;
     private final String messageTemplate;

--- a/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
+++ b/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
@@ -65,7 +65,8 @@ public enum ErrorCode {
     ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" ),
 
     HEART_TYPE_INVALID(BAD_REQUEST, "잘못된 반응 타입입니다"),
-    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),;
+    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),
+    HEART_NOT_FOUND(NOT_FOUND, "반응 id : %s 가 존재하지 않습니다"),;
 
     private final HttpStatus httpStatus;
     private final String messageTemplate;

--- a/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
+++ b/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
@@ -28,7 +28,6 @@ public enum ErrorCode {
     INVALID_CERTIFICATION_NUMBER(BAD_REQUEST, "인증 번호가 유효하지 않습니다."),
     USER_PERMISSION(FORBIDDEN, "권한이 없는 사용자입니다"),
     USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 id : %s 가 존재하지 않습니다"),
-    EMAIL_DOMAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 도메인이 존재하지 않습니다"),
 
     //Infra Exception
     OTHER_SERVER_BAD_REQUEST(BAD_REQUEST, "외부 api 400에러"),
@@ -62,11 +61,7 @@ public enum ErrorCode {
     ANSWER_NOT_FOUND(NOT_FOUND, "답변 id : %s 가 존재하지 않습니다"),
     ADOPTED_REVIEW_INVALID(BAD_REQUEST,"올바르지 않은 채택 리뷰입니다" ),
     ANSWER_ALREADY_ADOPTED(CONFLICT, "이미 채택된 답변입니다"),
-    ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" ),
-
-    HEART_TYPE_INVALID(BAD_REQUEST, "잘못된 반응 타입입니다"),
-    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),
-    HEART_NOT_FOUND(NOT_FOUND, "반응 id : %s 가 존재하지 않습니다"),;
+    ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" );
 
     private final HttpStatus httpStatus;
     private final String messageTemplate;

--- a/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
+++ b/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
@@ -61,7 +61,10 @@ public enum ErrorCode {
     ANSWER_NOT_FOUND(NOT_FOUND, "답변 id : %s 가 존재하지 않습니다"),
     ADOPTED_REVIEW_INVALID(BAD_REQUEST,"올바르지 않은 채택 리뷰입니다" ),
     ANSWER_ALREADY_ADOPTED(CONFLICT, "이미 채택된 답변입니다"),
-    ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" );
+    ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" ),
+
+    HEART_TYPE_INVALID(BAD_REQUEST, "잘못된 반응 타입입니다"),
+    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),;
 
     private final HttpStatus httpStatus;
     private final String messageTemplate;

--- a/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
+++ b/RevUp-common/src/main/java/com/revup/error/ErrorCode.java
@@ -62,7 +62,10 @@ public enum ErrorCode {
     ANSWER_NOT_FOUND(NOT_FOUND, "답변 id : %s 가 존재하지 않습니다"),
     ADOPTED_REVIEW_INVALID(BAD_REQUEST,"올바르지 않은 채택 리뷰입니다" ),
     ANSWER_ALREADY_ADOPTED(CONFLICT, "이미 채택된 답변입니다"),
-    ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" );
+    ANSWER_NOT_LINKED(BAD_REQUEST,"해당 답변은 이 질문에 속하지 않습니다" ),
+
+    HEART_TYPE_INVALID(BAD_REQUEST, "잘못된 반응 타입입니다"),
+    HEART_ALREADY_EXIST(CONFLICT, "이미 해당 답변에 반응이 존재합니다"),;
 
     private final HttpStatus httpStatus;
     private final String messageTemplate;

--- a/RevUp-domain/src/main/java/com/revup/answer/entity/Answer.java
+++ b/RevUp-domain/src/main/java/com/revup/answer/entity/Answer.java
@@ -89,19 +89,13 @@ public class Answer extends SoftDeleteEntity {
         this.content = content;
     }
 
-    public void increaseGoodCount(){
-        this.goodCount++;
+    public void updateGoodCount(int count) {
+        this.goodCount += count;
     }
 
-    public void increaseBadCount(){
-        this.badCount++;
+    public void updateBadCount(int count) {
+
+        this.badCount += count;
     }
 
-    public void decreaseGoodCount(){
-        this.goodCount--;
-    }
-
-    public void decreaseBadCount(){
-        this.badCount--;
-    }
 }

--- a/RevUp-domain/src/main/java/com/revup/answer/entity/Answer.java
+++ b/RevUp-domain/src/main/java/com/revup/answer/entity/Answer.java
@@ -3,6 +3,7 @@ package com.revup.answer.entity;
 import com.revup.answer.enums.AdoptedReview;
 import com.revup.common.BooleanStatus;
 import com.revup.common.SoftDeleteEntity;
+import com.revup.heart.enums.HeartType;
 import com.revup.question.entity.Question;
 import com.revup.user.entity.User;
 import jakarta.persistence.*;
@@ -86,5 +87,21 @@ public class Answer extends SoftDeleteEntity {
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    public void increaseGoodCount(){
+        this.goodCount++;
+    }
+
+    public void increaseBadCount(){
+        this.badCount++;
+    }
+
+    public void decreaseGoodCount(){
+        this.goodCount--;
+    }
+
+    public void decreaseBadCount(){
+        this.badCount--;
     }
 }

--- a/RevUp-domain/src/main/java/com/revup/answer/exception/AnswerNotFoundException.java
+++ b/RevUp-domain/src/main/java/com/revup/answer/exception/AnswerNotFoundException.java
@@ -5,6 +5,6 @@ import com.revup.error.ErrorCode;
 
 public class AnswerNotFoundException extends AppException {
     public AnswerNotFoundException(Long id) {
-        super(ErrorCode.ANSWER_NOT_FOUND);
+        super(ErrorCode.ANSWER_NOT_FOUND,id);
     }
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/HeartType.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/HeartType.java
@@ -1,5 +1,0 @@
-package com.revup.heart;
-
-public enum HeartType {
-    GOOD,BAD
-}

--- a/RevUp-domain/src/main/java/com/revup/heart/entity/Heart.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/entity/Heart.java
@@ -1,10 +1,12 @@
-package com.revup.heart;
+package com.revup.heart.entity;
 
 import com.revup.answer.entity.Answer;
 import com.revup.common.BaseTimeEntity;
+import com.revup.heart.enums.HeartType;
 import com.revup.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +29,18 @@ public class Heart extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "answer_id")
     private Answer answer;
+
+    @Builder
+    private Heart(User user, HeartType type) {
+        this.user = user;
+        this.type = type;
+    }
+
+    public void assignAnswer(Answer answer){
+        this.answer = answer;
+    }
+
+    public boolean isGood(){
+        return this.type.isGood();
+    }
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/entity/Heart.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/entity/Heart.java
@@ -32,4 +32,18 @@ public class Heart extends SoftDeleteEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "answer_id")
     private Answer answer;
+
+    @Builder
+    private Heart(User user, HeartType type) {
+        this.user = user;
+        this.type = type;
+    }
+
+    public void assignAnswer(Answer answer){
+        this.answer = answer;
+    }
+
+    public boolean isGood(){
+        return this.type.isGoodType();
+    }
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/entity/Heart.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/entity/Heart.java
@@ -2,6 +2,7 @@ package com.revup.heart.entity;
 
 import com.revup.answer.entity.Answer;
 import com.revup.common.BaseTimeEntity;
+import com.revup.common.SoftDeleteEntity;
 import com.revup.heart.enums.HeartType;
 import com.revup.user.entity.User;
 import jakarta.persistence.*;
@@ -9,12 +10,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @Table(name = "heart")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Heart extends BaseTimeEntity {
+@SQLRestriction("is_deleted = 'FALSE'")
+public class Heart extends SoftDeleteEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -41,6 +44,6 @@ public class Heart extends BaseTimeEntity {
     }
 
     public boolean isGood(){
-        return this.type.isGood();
+        return this.type.isGoodType();
     }
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/entity/Heart.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/entity/Heart.java
@@ -32,18 +32,4 @@ public class Heart extends SoftDeleteEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "answer_id")
     private Answer answer;
-
-    @Builder
-    private Heart(User user, HeartType type) {
-        this.user = user;
-        this.type = type;
-    }
-
-    public void assignAnswer(Answer answer){
-        this.answer = answer;
-    }
-
-    public boolean isGood(){
-        return this.type.isGoodType();
-    }
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/enums/HeartType.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/enums/HeartType.java
@@ -1,0 +1,21 @@
+package com.revup.heart.enums;
+
+import com.revup.heart.exception.InvalidHeartTypeException;
+
+public enum HeartType {
+    GOOD,BAD;
+
+    public static HeartType of(String type){
+        try {
+            return HeartType.valueOf(type.toUpperCase());
+        }
+        catch (IllegalArgumentException e){
+            throw new InvalidHeartTypeException();
+        }
+    }
+
+    public boolean isGoodType(){
+        return HeartType.GOOD == this;
+    }
+
+}

--- a/RevUp-domain/src/main/java/com/revup/heart/exception/HeartExistException.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/exception/HeartExistException.java
@@ -1,0 +1,10 @@
+package com.revup.heart.exception;
+
+import com.revup.error.AppException;
+import com.revup.error.ErrorCode;
+
+public class HeartExistException extends AppException {
+    public HeartExistException() {
+        super(ErrorCode.HEART_ALREADY_EXIST);
+    }
+}

--- a/RevUp-domain/src/main/java/com/revup/heart/exception/HeartNotFoundException.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/exception/HeartNotFoundException.java
@@ -4,7 +4,7 @@ import com.revup.error.AppException;
 import com.revup.error.ErrorCode;
 
 public class HeartNotFoundException extends AppException {
-    public HeartNotFoundException(Long id) {
-        super(ErrorCode.HEART_NOT_FOUND, id);
+    public HeartNotFoundException() {
+        super(ErrorCode.HEART_NOT_FOUND);
     }
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/exception/HeartNotFoundException.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/exception/HeartNotFoundException.java
@@ -1,0 +1,10 @@
+package com.revup.heart.exception;
+
+import com.revup.error.AppException;
+import com.revup.error.ErrorCode;
+
+public class HeartNotFoundException extends AppException {
+    public HeartNotFoundException(Long id) {
+        super(ErrorCode.HEART_NOT_FOUND, id);
+    }
+}

--- a/RevUp-domain/src/main/java/com/revup/heart/exception/InvalidHeartTypeException.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/exception/InvalidHeartTypeException.java
@@ -1,0 +1,10 @@
+package com.revup.heart.exception;
+
+import com.revup.error.AppException;
+import com.revup.error.ErrorCode;
+
+public class InvalidHeartTypeException extends AppException {
+    public InvalidHeartTypeException() {
+        super(ErrorCode.HEART_TYPE_INVALID);
+    }
+}

--- a/RevUp-domain/src/main/java/com/revup/heart/port/HeartPort.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/port/HeartPort.java
@@ -3,10 +3,11 @@ package com.revup.heart.port;
 import java.util.Map;
 
 public interface HeartPort {
-    void incrementGoodHeart(Long answerId, Long userId);
-    void incrementBadHeart(Long answerId, Long userId);
-    void decrementGoodHeart(Long answerId, Long userId);
-    void decrementBadHeart(Long answerId, Long userId);
     Map<Long, Map<String, Integer>> getHeartCounts();
-    void clearHearts();
+
+    boolean processLike(Long answerId, Long id, boolean isGood);
+
+    boolean cancelLike(Long answerId, Long userId, boolean isGood);
+
+    void clearHeartCounts();
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/port/HeartPort.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/port/HeartPort.java
@@ -1,0 +1,12 @@
+package com.revup.heart.port;
+
+import java.util.Map;
+
+public interface HeartPort {
+    void incrementGoodHeart(Long answerId, Long userId);
+    void incrementBadHeart(Long answerId, Long userId);
+    void decrementGoodHeart(Long answerId, Long userId);
+    void decrementBadHeart(Long answerId, Long userId);
+    Map<Long, Map<String, Integer>> getHeartCounts();
+    void clearHearts();
+}

--- a/RevUp-domain/src/main/java/com/revup/heart/repository/HeartRepository.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/repository/HeartRepository.java
@@ -4,8 +4,16 @@ import com.revup.answer.entity.Answer;
 import com.revup.heart.entity.Heart;
 import com.revup.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface HeartRepository extends JpaRepository<Heart, Long> {
     boolean existsHeartByAnswerAndUser(Answer answer, User user);
 
+    @Query("select h from Heart h join fetch h.user where h.id=:id")
+    Optional<Heart> findByIdWithUser(Long id);
+
+    @Query("select h from Heart h join fetch h.user join fetch h.answer where h.id=:id")
+    Optional<Heart> findByIdWithUserAndAnswer(Long id);
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/repository/HeartRepository.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/repository/HeartRepository.java
@@ -16,4 +16,6 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     @Query("select h from Heart h join fetch h.user join fetch h.answer where h.id=:id")
     Optional<Heart> findByIdWithUserAndAnswer(Long id);
+
+    Optional<Heart> findByAnswerIdAndUserId(Long answerId, Long userId);
 }

--- a/RevUp-domain/src/main/java/com/revup/heart/repository/HeartRepository.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/repository/HeartRepository.java
@@ -1,0 +1,11 @@
+package com.revup.heart.repository;
+
+import com.revup.answer.entity.Answer;
+import com.revup.heart.entity.Heart;
+import com.revup.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HeartRepository extends JpaRepository<Heart, Long> {
+    boolean existsHeartByAnswerAndUser(Answer answer, User user);
+
+}

--- a/RevUp-domain/src/main/java/com/revup/heart/service/HeartService.java
+++ b/RevUp-domain/src/main/java/com/revup/heart/service/HeartService.java
@@ -1,0 +1,45 @@
+package com.revup.heart.service;
+
+import com.revup.answer.entity.Answer;
+import com.revup.answer.exception.AnswerNotFoundException;
+import com.revup.answer.repository.AnswerRepository;
+import com.revup.heart.entity.Heart;
+import com.revup.heart.exception.HeartExistException;
+import com.revup.heart.repository.HeartRepository;
+import com.revup.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HeartService {
+    private final HeartRepository heartRepository;
+    private final AnswerRepository answerRepository;
+
+    @Transactional
+    public Long createHeart(Long answerId, Heart heart, User currentUser) {
+        // 답변 조회
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+        // 이미 해당 답변과 유저에 대한 반응이 존재하면 에러 반환
+        if (heartRepository.existsHeartByAnswerAndUser(answer, currentUser)) {
+            throw new HeartExistException();
+        }
+
+        heart.assignAnswer(answer);
+
+        if (heart.isGood()) {
+            answer.increaseGoodCount();
+        } else {
+            answer.increaseBadCount();
+        }
+
+
+        return heartRepository.save(heart).getId();
+
+    }
+
+}

--- a/RevUp-domain/src/main/resources/application-domain.yml
+++ b/RevUp-domain/src/main/resources/application-domain.yml
@@ -24,6 +24,12 @@ spring:
       data-locations: classpath:sql/data.sql
       mode: always
 
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql: trace
+    root: info
+
 ---
 
 spring:

--- a/RevUp-infra/src/main/java/com/revup/heart/adaptor/HeartAdaptor.java
+++ b/RevUp-infra/src/main/java/com/revup/heart/adaptor/HeartAdaptor.java
@@ -1,0 +1,103 @@
+package com.revup.heart.adaptor;
+
+import com.revup.heart.port.HeartPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class HeartAdaptor implements HeartPort {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String HEART_KEY = "heart_counts";
+    private static final String USER_HEART_KEY = "user_hearts";
+
+    @Override
+    public void incrementGoodHeart(Long answerId, Long userId) {
+        String field = generateField(answerId, userId);
+        if (!isDuplicate(field)) { // 중복 체크
+            redisTemplate.opsForHash().increment(HEART_KEY, generateAnswerField(answerId, true), 1);
+            redisTemplate.opsForSet().add(USER_HEART_KEY, field);
+        }
+    }
+
+    @Override
+    public void incrementBadHeart(Long answerId, Long userId) {
+        String field = generateField(answerId, userId);
+        if (!isDuplicate(field)) { // 중복 체크
+            redisTemplate.opsForHash().increment(HEART_KEY, generateAnswerField(answerId, false), 1);
+            redisTemplate.opsForSet().add(USER_HEART_KEY, field);
+        }
+    }
+
+    @Override
+    public void decrementGoodHeart(Long answerId, Long userId) {
+        String field = generateField(answerId, userId);
+        if (isDuplicate(field)) { // 필드가 존재하면 삭제
+            redisTemplate.opsForHash().increment(HEART_KEY, generateAnswerField(answerId, true), -1);
+            redisTemplate.opsForSet().remove(USER_HEART_KEY, field);
+        }
+    }
+
+    @Override
+    public void decrementBadHeart(Long answerId, Long userId) {
+        String field = generateField(answerId, userId);
+        if (isDuplicate(field)) { // 필드가 존재하면 삭제
+            redisTemplate.opsForHash().increment(HEART_KEY, generateAnswerField(answerId, false), -1);
+            redisTemplate.opsForSet().remove(USER_HEART_KEY, field);
+        }
+    }
+
+
+    @Override
+    public Map<Long, Map<String, Integer>> getHeartCounts() {
+        // entries: "answerId:type" -> count 형태의 키-값 쌍
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(HEART_KEY);
+
+        // 결과 저장할 map
+        // key: answerId(Long), value: { "good": count, "bad": count } 형태의 Map
+        Map<Long, Map<String, Integer>> result = new HashMap<>();
+
+        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
+            // answerId:type
+            String field = (String) entry.getKey();
+            Integer count = Integer.valueOf(entry.getValue().toString());
+
+            // ":"로 분리하여 answerId와 type 추출
+            String[] parts = field.split(":");
+            Long answerId = Long.valueOf(parts[0]);
+            String type = parts[1];
+
+            // 결과 Map에 데이터 저장
+            // answerId에 해당하는 서브 맵(Map<String, Integer>)을 가져오거나 생성한 후 값을 추가
+            result.computeIfAbsent(answerId, k -> new HashMap<>()).put(type, count);
+        }
+        return result;
+    }
+
+    @Override
+    public void clearHearts() {
+        redisTemplate.delete(HEART_KEY);
+        redisTemplate.delete(USER_HEART_KEY); // 중복 방지 데이터 초기화
+    }
+
+
+    private boolean isDuplicate(String field) {
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(USER_HEART_KEY, field));
+    }
+
+
+    private String generateField(Long answerId, Long userId) {
+        return answerId + ":" + userId;
+    }
+
+
+    private String generateAnswerField(Long answerId, boolean isGood) {
+        return answerId + ":" + (isGood ? "good" : "bad");
+    }
+}

--- a/RevUp-infra/src/main/java/com/revup/heart/batch/HeartBatchScheduler.java
+++ b/RevUp-infra/src/main/java/com/revup/heart/batch/HeartBatchScheduler.java
@@ -11,7 +11,7 @@ public class HeartBatchScheduler {
     private final HeartService heartService;
 
     @Scheduled(cron = "0 */1 * * * *")
-    public void updateHeartsCount(){
-        heartService.updateHeartsCount();
+    public void syncHeartsCount(){
+        heartService.syncHeartsCount();
     }
 }

--- a/RevUp-infra/src/main/java/com/revup/heart/batch/HeartBatchScheduler.java
+++ b/RevUp-infra/src/main/java/com/revup/heart/batch/HeartBatchScheduler.java
@@ -1,0 +1,17 @@
+package com.revup.heart.batch;
+
+import com.revup.heart.service.HeartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HeartBatchScheduler {
+    private final HeartService heartService;
+
+    @Scheduled(cron = "0 */1 * * * *")
+    public void updateHeartsCount(){
+        heartService.updateHeartsCount();
+    }
+}

--- a/RevUp-infra/src/main/java/com/revup/heart/config/SchedulerConfig.java
+++ b/RevUp-infra/src/main/java/com/revup/heart/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.revup.heart.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/RevUp-infra/src/main/java/com/revup/redis/config/RedisConfig.java
+++ b/RevUp-infra/src/main/java/com/revup/redis/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.revup.redis;
+package com.revup.redis.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -8,7 +8,9 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 
@@ -23,7 +25,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int redisPort;
 
-    @Value("${spring.data.redis.password}")
+    @Value("${spring.data.redis.password:}")
     private String redisPassword;
 
     @Bean
@@ -42,5 +44,15 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisConfig, clientConfig);
     }
 
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key : value 시리얼 라이저
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
 
 }

--- a/RevUp-infra/src/main/java/com/revup/redis/config/RedissonConfig.java
+++ b/RevUp-infra/src/main/java/com/revup/redis/config/RedissonConfig.java
@@ -1,4 +1,4 @@
-package com.revup.feedback;
+package com.revup.redis.config;
 
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #25 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
# 좋아요/싫어요 기능 구현
좋아요 테이블 이름을 Like로 두면 예약어라 안된다고 해서 Heart로 두고 진행했습니다
## 1. 좋아요/싫어요 추가 요청 처리 흐름
### Redis의 Set에서 중복 검사
- 요청된 answerId:userId가 Redis Set에 이미 존재하는 경우 에러를 반환합니다.
### 중복 검사를 통과하면
- Redis Hash에서 answerId:type(good 혹은 bad)의 카운트를 증가시킵니다.
- DB의 Heart 테이블에 해당 좋아요/싫어요 기록을 저장합니다.

## 2. 좋아요/싫어요 취소 요청 처리 흐름
### Redis의 Set에서 데이터 확인
- 요청된 answerId:userId가 Redis Set에 존재하지 않는 경우 에러를 반환합니다
### 데이터가 존재하면
- Redis Hash에서 answerId:type의 카운트를 감소시킵니다.
- DB의 Heart 테이블에서 해당 좋아요/싫어요 데이터를 soft delete 처리합니다.

## 스케줄러
1분마다 Redis Hash에 저장된 answerId:type 카운트를 DB의 Answer 엔티티(goodCount, badCount 컬럼)에 업데이트합니다.
업데이트 후 Redis Hash는 초기화(clear)합니다

## 구현하면서 어려웠던 점
Redis의 Set에 answerId:userId 형태로 데이터를 저장하므로, 특정 답변에 특정 유저가 좋아요/싫어요를 눌렀는지 확인이 가능한거 같아서  Heart 테이블이 굳이 필요할까? 라는 생각이 조금 들었습니다
저희 요구사항 중에 특정 답변에 좋아요를 누른 유저 정보들 조회라는 요구사항이 있어 이 부분때문에 Heart 테이블을 그대로 두긴 했습니다 

우선 생각나는 흐름 대로 구현을 해봤는데 스스로도 뭔가 정리가 잘 안되는거 같고, 흐름이 헷갈리는거 같습니다.. 
더 나은 방식이나 수정이 필요한 곳 있으면 피드백 부탁드립니다! 
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
